### PR TITLE
Non-blocking TCP sockets in Raft shim

### DIFF
--- a/src/Shim.ml
+++ b/src/Shim.ml
@@ -202,6 +202,7 @@ module Shim (A: ARRANGEMENT) = struct
   let new_client_conn env =
     let (client_fd, client_addr) = accept env.clients_fd in
     let c = A.createClientId () in
+    set_nonblock client_fd;
     Hashtbl.add env.client_read_fds client_fd c;
     Hashtbl.add env.client_write_fds c client_fd;
     printf "client %s connected on %s" (A.serializeClientId c) (string_of_sockaddr client_addr);

--- a/src/Shim.ml
+++ b/src/Shim.ml
@@ -147,6 +147,7 @@ module Shim (A: ARRANGEMENT) = struct
     Unix.bind env.nodes_fd (Unix.ADDR_INET (Unix.inet_addr_any, port));
     Unix.bind env.clients_fd (Unix.ADDR_INET (Unix.inet_addr_any, cfg.port));
     Unix.listen env.clients_fd 8;
+    Unix.set_nonblock env.clients_fd;
     (env, initial_state)
 
   let disconnect_client env fd reason =

--- a/src/Shim.ml
+++ b/src/Shim.ml
@@ -157,6 +157,7 @@ module Shim (A: ARRANGEMENT) = struct
     let c = undenote_client env fd in
     Hashtbl.remove env.client_read_fds fd;
     Hashtbl.remove env.client_write_fds c;
+    Hashtbl.remove env.client_read_bufs fd;
     Unix.close fd;
     printf "client %s disconnected: %s" (A.serializeClientId c) reason;
     print_newline ()
@@ -179,14 +180,11 @@ module Shim (A: ARRANGEMENT) = struct
       printf "output: failed to find socket for client %s" (A.serializeClientId c);
       print_newline ()
     | Disconnect s ->
-      disconnect_client env
-                        (denote_client env c)
-                        (sprintf "output: failed send to client %s: %s"
-                                 (A.serializeClientId c) s)
+      disconnect_client env (denote_client env c)
+        (sprintf "output: failed send to client %s: %s" (A.serializeClientId c) s)
     | Unix.Unix_error (err, fn, _) ->
-       disconnect_client env
-                         (denote_client env c)
-                         (sprintf "output: error %s" (Unix.error_message err))
+       disconnect_client env (denote_client env c)
+         (sprintf "output: error %s" (Unix.error_message err))
 
   let save env (step : log_step) (st : A.state)  =
     if (env.saves > 0 && env.saves mod 1000 = 0) then begin

--- a/src/Util.ml
+++ b/src/Util.ml
@@ -109,13 +109,11 @@ let keys_of_hashtbl h =
 exception Disconnect of string
 
 (* throws Unix_error, Disconnect *)
-let rec send_all fd buf len =
-  if len > 0 then begin
-    let n = Unix.send fd buf 0 len [] in
+let rec send_all fd buf offset len =
+  if offset < len then begin
+    let n = Unix.send fd buf offset (len - offset) [] in
     if n = 0 then raise (Disconnect "send_all: other side closed connection");
-    let len' = len - n in
-    let buf' = Bytes.sub buf n len' in
-    send_all fd buf' len'
+    send_all fd buf (offset + n) len
   end
 
 (* throws Unix_error, Disconnect *)
@@ -123,7 +121,7 @@ let send_chunk fd buf =
   let len = Bytes.length buf in
   let n = Unix.send fd (raw_bytes_of_int len) 0 4 [] in
   if n < 4 then raise (Disconnect "send_chunk: message header failed to send all at once");
-  send_all fd buf len
+  send_all fd buf 0 len
 
 (* throws Unix_error, Disconnect *)
 let recv_chunk fd ht =


### PR DESCRIPTION
Non-blocking TCP sockets are relevant in settings without forking. This PR experimentally enables them for the Raft shim for further testing.