### PR TITLE
Correct client id handling in Shim

### DIFF
--- a/src/Shim.mli
+++ b/src/Shim.mli
@@ -15,14 +15,13 @@ module type ARRANGEMENT = sig
   val set_timeout : name -> state -> float
   val deserialize_msg : bytes -> msg
   val serialize_msg : msg -> bytes
-  val deserialize_input : bytes -> client_id -> input option
+  val deserialize_input : bytes -> (client_id * input) option
   val serialize_output : output -> client_id * bytes
   val debug : bool
   val debug_input : state -> input -> unit
   val debug_recv : state -> (name * msg) -> unit
   val debug_send : state -> (name * msg) -> unit
   val debug_timeout : state -> unit
-  val create_client_id : unit -> client_id
   val string_of_client_id : client_id -> string
 end
 


### PR DESCRIPTION
The way we currently handle client ids in VarD is pretty broken, since
if a client connects to multiple Raft servers (say, in the case of a
failover) it will have different ids! This new shim fixes this, since
it expects clients to send their ids with every request and associates
sockets with ids on this basis. Clients are now responsible for
ensuring id uniqueness.