### PR TITLE
Pin yojson dependency to last compatible version, 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 - [`topkg`](http://erratique.ch/software/topkg)
 - [`cheerios-runtime`](https://github.com/uwplse/cheerios)
 - [`base64`](https://github.com/mirage/ocaml-base64) (3.0.0 or later)
-- [`yojson`](https://github.com/ocaml-community/yojson)
+- [`yojson`](https://github.com/ocaml-community/yojson) (no later than 1.7.0)
 
 Installation
 ------------

--- a/opam
+++ b/opam
@@ -11,7 +11,7 @@ synopsis: "Verdi framework runtime library"
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "yojson"
+  "yojson" {<= "1.7.0"}
   "base64" {>= "3.0.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}


### PR DESCRIPTION
Hello,

We're working on a related research project (https://github.com/DistCompiler/pgo), and, as part of our evaluation, we've been running experiments to compare our Raft implementation with the Verdi Raft project.

24 days ago, yojson released their version 2.0.0, removing the deprecated type `json` that verdi-runtime uses, and a random clean rebuild of verdi-runtime by us failed sometime later. verdi-runtime unfortunately depends on the latest version of that library, so I assume all fresh builds of this library broke 24 days ago.

This PR fixes that issue in the simplest way someone who has only read OCaml code occasionally knows how, by adding a version constraint to the package definition. I think I've tested it and clean builds work now, but I'd be happy to fix any ignorant oversights on my part.

I would also like to add that, this one random issue aside, working with your artifact has been great and everything worked perfectly out of the box for >6 months. Your packaging and documentation are much appreciated.